### PR TITLE
Updated snyk organization id

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -9,6 +9,11 @@ metadata:
    uplightinc.atlassian.net/sla: https://uplightinc.atlassian.net/wiki/spaces/JAG/pages/7436894395/Marketplace+-+Service+Level+Agreements
    uplightinc.atlassian.net/sli: https://uplightinc.atlassian.net/wiki/spaces/JAG/pages/7445774739/Marketplace+-+Service+Level+Indicators
    uplightinc.atlassian.net/slo: https://uplightinc.atlassian.net/wiki/spaces/JAG/pages/7446200322/Marketplace+-+Service+Level+Objectives
+   snyk.io/org-id: 4a1bba66-4be8-4eb0-8a24-c1219a94df5a
+  links:
+  - url: https://app.apptio.com/cloudability#/dashboards/1218243?viewId=452568
+    title: Cloud Cost Dashboard
+    icon: dashboard
 spec:
   type: library
   lifecycle: production


### PR DESCRIPTION
Jira Ticket(s)
[MP2-7198](https://uplightinc.atlassian.net/browse/MP2-7198)

What was the problem/requirement?
Snyk org Id and Apptio Cloudability dashboard URL is mising in snyk

How was it solved?
Adding Snyk org Id and Apptio Cloudability dashboard URL in catalog-info.yaml.

[MP2-7198]: https://uplightinc.atlassian.net/browse/MP2-7198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ