### PR TITLE
add. StartTime & EndTime job params for custom 24hr window

### DIFF
--- a/cartridges/int_cybersource_sfra/cartridge/scripts/jobs/DMOrderStatusUpdate.js
+++ b/cartridges/int_cybersource_sfra/cartridge/scripts/jobs/DMOrderStatusUpdate.js
@@ -77,13 +77,26 @@ function parseJSONResponse(message, orderHashMap) {
 /**
  * Function to set date time parameter to provide
  * as an input. The date range will pick
- * records of 24 hours before the current time
- * @returns {*} obj
+ * records of 24 hours before the current time.
+ * If explicit StartTime/EndTime job params are provided (format: yyyy-MM-dd'T'HH:mm:ss.SSS'Z'),
+ * those will be used directly instead of the lookback calculation.
+ * NOTE: CyberSource API enforces a max range of 24 hours per request.
+ * @param {Object} jobParams jobParams
+ * @returns {Object} obj
  */
-function setDateTimeForParameter() {
+function setDateTimeForParameter(jobParams) {
     var System = require('dw/system/System');
     var StringUtils = require('dw/util/StringUtils');
     var time = {};
+
+    // Use explicit job parameters if provided (for backfill scenarios)
+    if (jobParams && !empty(jobParams.StartTime) && !empty(jobParams.EndTime)) {
+        logger.info('Using explicit StartTime: {0} and EndTime: {1} from job parameters', jobParams.StartTime, jobParams.EndTime);
+        time.start = jobParams.StartTime;
+        time.end = jobParams.EndTime;
+        return time;
+    }
+
     var endDate = System.getCalendar();
     endDate.setTimeZone('GMT');
     time.end = StringUtils.formatCalendar(endDate, 'yyyy-MM-dd\'T\'HH:mm:ss.SSS\'Z\'');
@@ -203,7 +216,7 @@ function orderStatusUpdate(jobParams) {
     //  Process Orders and change status in SFCC
     if (orderHashMap.length > 0) {
         //  Mapping request object with correct parameter
-        var time = setDateTimeForParameter();
+        var time = setDateTimeForParameter(jobParams);
         var responseObj = null;
 
         //  Call conversion report service


### PR DESCRIPTION
### User Story
[MP2-8964](https://simpleenergy.atlassian.net/browse/MP2-8964)

### What was the problem/requirement?
From 13 May 2026 to 18 May 2026, only IID was set as Site Scope for CSDecisionManagerOrderUpdate job. Hence, orders of other utilities were not getting confirmed even after being accepted by the Decision Manager. 

On analysis we found that the CSDecisionManagerOrderUpdate job only processes records created within the last 24 hours, controlled by the custom preference CsOrderImportLookBack. When this look back window in increased beyond 24 hours, the CyberSource API returns the following error: "Duration of the dates is exceeding the range of 1 days." This means the CyberSource Conversion Detail Report API has a hard limit of 24 hours per request which made it impossible to backfill older records by simply increasing the preference value.

### What was the solution?
Added StartTime & EndTime param in the job to run for every 24 hours window starting from 13 May 2026 (eg. 13-14 May, 14-15 May etc.)


[MP2-8964]: https://uplightinc.atlassian.net/browse/MP2-8964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ