### PR TITLE
update. empty start & end time params check

### DIFF
--- a/cartridges/int_cybersource_sfra/cartridge/scripts/jobs/DMOrderStatusUpdate.js
+++ b/cartridges/int_cybersource_sfra/cartridge/scripts/jobs/DMOrderStatusUpdate.js
@@ -90,10 +90,14 @@ function setDateTimeForParameter(jobParams) {
     var time = {};
 
     // Use explicit job parameters if provided (for backfill scenarios)
-    if (jobParams && !empty(jobParams.StartTime) && !empty(jobParams.EndTime)) {
-        logger.info('Using explicit StartTime: {0} and EndTime: {1} from job parameters', jobParams.StartTime, jobParams.EndTime);
-        time.start = jobParams.StartTime;
-        time.end = jobParams.EndTime;
+    // Coerce to JS string via concatenation to handle Java String objects
+    var startTimeParam = (jobParams && jobParams.StartTime) ? (jobParams.StartTime + '').replace(/^\s+|\s+$/g, '') : '';
+    var endTimeParam = (jobParams && jobParams.EndTime) ? (jobParams.EndTime + '').replace(/^\s+|\s+$/g, '') : '';
+
+    if (startTimeParam !== '' && endTimeParam !== '') {
+        logger.info('Using explicit StartTime: {0} and EndTime: {1} from job parameters', startTimeParam, endTimeParam);
+        time.start = startTimeParam;
+        time.end = endTimeParam;
         return time;
     }
 


### PR DESCRIPTION
### User Story
[MP2-8981](https://simpleenergy.atlassian.net/browse/MP2-8981)

### What was the problem/requirement?
In continuation to [PR #9](https://github.com/simpleenergy/link_cybersource/pull/9), the StartTime & EndTime param was not getting added to the Cybersource Reporting URL and the job was getting triggered on the last 24 hour window only. 

### What was the solution?
Updated StartTime & EndTime param empty string check in the job. Tested on Sandbox env.

<img width="635" height="108" alt="SFCC Sandbox job logs with StartTime & EndTime param" src="https://github.com/user-attachments/assets/b49f6b13-5a67-484d-9221-fb4cdd1edaf2" />


[MP2-8981]: https://uplightinc.atlassian.net/browse/MP2-8981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ